### PR TITLE
Fixing App Dynamics Agent to 4.3 chain

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -15,7 +15,7 @@
 
 # Configuration for the AppDynamics framework
 ---
-version: 4.+
+version: 4.3.+
 repository_root: https://packages.appdynamics.com/java
 default_application_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
   puts \"#{a['space_name']}:#{a['application_name']}\"")


### PR DESCRIPTION
Locking App Dyanmics Agent to latest version in 4.3.*.*. This is required to have version of the agent be at or lower than the App Dynamics Controller version. In the case of dedicated SaaS the controller is not always upto date with the latest agent. (Presently, the agent is 4.4.??, but the controller is still 4.3.4.1.